### PR TITLE
Added PHP dependancies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ may be found [here][repo-format]. Once you have made the desired changes, run
 ### Dependencies
 
   - [PHP](https://secure.php.net/)
+    * php-curl (Ubuntu: php7.0-curl)
+    * php-gmp (Ubuntu: php-gmp)
   - [Composer](https://getcomposer.org/)
   - [PEAR](https://pear.php.net/)
   - [PEAR Log Module](https://pear.php.net/package/Log/)


### PR DESCRIPTION
XDMoD requires two additional PHP deps to build on Ubuntu.
Those builds are not included in the README, nor are they automatically pulled in by composer.

Until these are automaticall pulled in by one of the build tools, we should list them in the README.